### PR TITLE
113456: bump version to v0.10.0

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,11 +5,10 @@ source "https://rubygems.org"
 # Specify your gem's dependencies in resource_registry.gemspec
 gemspec
 
-
- if Gem::Version.new(RUBY_VERSION) >= Gem::Version.new('3.1.0')
-     gem 'bigdecimal'
-     gem 'mutex_m'
-     gem 'base64'
-     gem 'ostruct'
- end
+if Gem::Version.new(RUBY_VERSION) >= Gem::Version.new('3.1.0')
+  gem 'bigdecimal'
+  gem 'mutex_m'
+  gem 'base64'
+  gem 'ostruct'
+end
  

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    resource_registry (0.7.0)
+    resource_registry (0.10.0)
       bootsnap (~> 1.0)
       deep_merge (>= 1.0.0)
       dry-configurable (~> 0.12)
@@ -196,7 +196,7 @@ DEPENDENCIES
   resource_registry!
   rspec (~> 3.9)
   rspec-rails (~> 3.9)
-  rubocop (~> 0.74.0)
+  rubocop
   simplecov
   timecop (~> 0.9.8)
   yard (~> 0.9)

--- a/resource_registry.gemspec
+++ b/resource_registry.gemspec
@@ -53,7 +53,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'simplecov'
   spec.add_development_dependency 'database_cleaner', '~> 1.7'
   spec.add_development_dependency 'timecop',          '~> 0.9.8'
-  spec.add_development_dependency 'rubocop',          '~> 0.74.0'
+  spec.add_development_dependency 'rubocop'
   spec.add_development_dependency 'yard',             '~> 0.9'
   spec.add_development_dependency 'pry-byebug'
 


### PR DESCRIPTION
Ticket: https://redmine.priv.dchbx.org/issues/113456

RM-113456

Note: VERSION constant was already updated to `0.10.0` in https://github.com/dchbx/resource_registry/pull/12